### PR TITLE
Always use overall Obsidian link types

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -9,7 +9,7 @@ import {
 	setIcon,
 } from "obsidian";
 import fuzzysort from "fuzzysort";
-import { AtSymbolLinkingSettings, LinkType } from "src/settings/settings";
+import { AtSymbolLinkingSettings } from "src/settings/settings";
 import { highlightSearch } from "./utils";
 
 type fileOption = {
@@ -226,28 +226,18 @@ export default class SuggestionPopup extends EditorSuggest<
 				this.context.end
 			) || "";
 
-		let linkText = "";
-		if (this.settings.linkType === LinkType.WIKI_STYLE) {
-			let filePath = value.obj?.filePath;
-			if (filePath.endsWith(".md")) {
-				filePath = filePath.slice(0, -3);
-			}
-			linkText = `[[${filePath}|${
-				this.settings.includeSymbol ? "@" : ""
-			}${value.obj?.alias || value.obj?.fileName}]]`;
-		} else if (this.settings.linkType === LinkType.MARKDOWN_STYLE) {
-			const currentFile = this.app.workspace.getActiveFile();
-			const linkFile = this.app.vault.getAbstractFileByPath(
-				value.obj?.filePath
-			) as TFile;
-			linkText = this.app.fileManager.generateMarkdownLink(
-				linkFile,
-				currentFile?.path || ""
-			);
-			if (this.settings.includeSymbol) {
-				linkText = "[@" + linkText.substring(1);
-			}
-		}
+		const currentFile = this.app.workspace.getActiveFile();
+		const linkFile = this.app.vault.getAbstractFileByPath(
+			value.obj?.filePath
+		) as TFile;
+		let alias = value.obj?.alias || undefined;
+		if (this.settings.includeSymbol) alias = `@${alias || value.obj?.fileName}`;
+		let linkText = this.app.fileManager.generateMarkdownLink(
+			linkFile,
+			currentFile?.path || "",
+			undefined, // we don't care about the subpath
+			alias
+		);
 
 		this.context?.editor.replaceRange(
 			linkText,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -2,20 +2,13 @@ import { App, ButtonComponent, PluginSettingTab, Setting } from "obsidian";
 import AtSymbolLinking from "src/main";
 import { FolderSuggest } from "./folder-suggest";
 
-export enum LinkType {
-	WIKI_STYLE = "Wiki style",
-	MARKDOWN_STYLE = "Markdown style",
-}
-
 export interface AtSymbolLinkingSettings {
 	limitLinkDirectories: Array<string>;
-	linkType: LinkType;
 	includeSymbol: boolean;
 }
 
 export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
 	limitLinkDirectories: [],
-	linkType: LinkType.WIKI_STYLE,
 	includeSymbol: true,
 };
 
@@ -52,35 +45,9 @@ export class SettingsTab extends PluginSettingTab {
 		);
 		new Setting(this.containerEl).setDesc(descEl);
 
-		// Begin linkType option: Determine which type of link to create
-		const linkTypeDesc = document.createDocumentFragment();
-		linkTypeDesc.append(
-			"Choose which type of link to create",
-			descEl.createEl("br"),
-			descEl.createEl("strong", { text: LinkType.WIKI_STYLE + " (default)" }),
-			' will create a link in the format "[[filePath|linkText]]"',
-			descEl.createEl("br"),
-			descEl.createEl("strong", { text: LinkType.MARKDOWN_STYLE }),
-			' will create a link in the format "[linkText](filePath)"'
-		);
-		new Setting(this.containerEl)
-			.setName("Link type")
-			.setDesc(linkTypeDesc)
-			.addDropdown((dropDown) =>
-				dropDown
-					.addOption(LinkType.WIKI_STYLE, LinkType.WIKI_STYLE)
-					.addOption(LinkType.MARKDOWN_STYLE, LinkType.MARKDOWN_STYLE)
-					.setValue(this.plugin.settings.linkType)
-					.onChange(async (value: LinkType) => {
-						this.plugin.settings.linkType = value;
-						this.plugin.saveSettings();
-					})
-			);
-		// End linkType option
-
 		// Begin includeSymbol option: Determine whether to include @ symbol in link
 		const includeSymbolDesc = document.createDocumentFragment();
-		linkTypeDesc.append(
+		includeSymbolDesc.append(
 			"Include the @ symbol in the found link",
 			descEl.createEl("br"),
 			"Toggle off to remove the @ symbol from the final link"


### PR DESCRIPTION
This simplifies the code somewhat by always deferring to the overall Obsidian link-type configuration.

This also has the advantage that we don't need to try and generate a wiki-style link manually -- and thus don't have to always alias. In other words, we can now generate a link like `[[Barry van Oudtshoorn]]` rather than `[[Contacts/Wonde/Barry van Oudtshoorn|Barry van Oudtshoorn]]` -- except and unless the Obsidian configuration is set to generate links in that way.

There's still support for the optional inclusion of the `@` symbol as an alias.