### PR TITLE
feat: Add Unicode for filename

### DIFF
--- a/src/compatibility-mode-extension/extension-handler.ts
+++ b/src/compatibility-mode-extension/extension-handler.ts
@@ -120,7 +120,7 @@ export function atSymbolTriggerExtension(
 				} else if (typedChar === "Escape") {
 					this.closeSuggestion();
 				} else if (
-					!isValidFileNameCharacter(typedChar) ||
+					!isValidFileNameCharacter(typedChar, settings.useUnicodeName) ||
 					event.altKey ||
 					event.metaKey ||
 					event.ctrlKey ||

--- a/src/native-suggestion/suggest-popup.ts
+++ b/src/native-suggestion/suggest-popup.ts
@@ -127,7 +127,7 @@ export default class SuggestionPopup extends EditorSuggest<
 		}
 
 		// If query is empty or doesn't have valid filename characters, close
-		if (!query || !isValidFileNameCharacter(typedChar)) {
+		if (!query || !isValidFileNameCharacter(typedChar, this.settings.useUnicodeName)) {
 			return this.closeSuggestion();
 		}
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -20,6 +20,7 @@ export interface AtSymbolLinkingSettings {
 
 	useCompatibilityMode: boolean;
 	leavePopupOpenForXSpaces: number;
+	useUnicodeName: boolean;
 }
 
 export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
@@ -33,6 +34,7 @@ export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
 
 	useCompatibilityMode: false,
 	leavePopupOpenForXSpaces: 0,
+	useUnicodeName: false,
 };
 
 const arrayMove = <T>(array: T[], fromIndex: number, toIndex: number): void => {
@@ -349,6 +351,18 @@ export class SettingsTab extends PluginSettingTab {
 					this.validate();
 				};
 			});
+		new Setting(this.containerEl)
+			.setName("Use Unicode for name")
+			.setDesc("Use any kind of letter from any language for filename.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.useUnicodeName)
+					.onChange((value: boolean) => {
+						this.plugin.settings.useUnicodeName = value;
+						this.plugin.saveSettings();
+						this.display();
+					})
+			);
 		// End leavePopupOpenForXSpaces option
 	}
 

--- a/src/utils/valid-file-name.ts
+++ b/src/utils/valid-file-name.ts
@@ -1,12 +1,19 @@
 const validCharRegex =
 	/[a-z0-9\\$\\-\\_\\!\\%\\"\\'\\.\\,\\*\\&\\(\\)\\;\\{\\}\\+\\=\\~\\`\\?\\<\\>)]/i;
 
-export const isValidFileNameCharacter = (char: string) => {
+const validUnicodeRegex = 
+	/[\p{Letter}0-9\\$\\-\\_\\!\\%\\"\\'\\.\\,\\*\\&\\(\\)\\;\\{\\}\\+\\=\\~\\`\\?\\<\\>)]/iu;
+
+export const isValidFileNameCharacter = (char: string, useUnicodeName: boolean) => {
 	if (char === " ") {
 		return true;
 	}
 	if (char === "\\") {
 		return false;
 	}
-	return validCharRegex.test(char);
+	if (useUnicodeName) {
+		return validUnicodeRegex.test(char);
+	} else {
+		return validCharRegex.test(char);
+	}
 };


### PR DESCRIPTION

Hello! Thank you for the interesting plugin. I'm trying to integrate it into my workflow.

However, I came across the fact that by default it supports ASCII characters only. And I, in turn, need the Cyrillic alphabet. Therefore, I decided to make some changes to your code.
   
Instead of limiting it to Cyrillic characters, I opted to add full Unicode support for all letters. I noticed that the Obsidian community is quite diverse in terms of languages. I achieved this by adding a new regular expression, replacing `a-z` with `[\P{Letter}](https://www.regular-expressions.info/unicode.html)`, which matches any Unicode letter. I'm not sure if it's a good idea, but it works for me personally.

I added a corresponding toggle in the settings to switch between using the Unicode regex, which is disabled by default.

I'm curious to hear your thoughts on these changes.