### PR TITLE
Add option to keep trigger symbol in file name

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -25,6 +25,7 @@ export interface AtSymbolLinkingSettings {
 	invalidCharacterRegexFlags: string;
 
 	removeAccents: boolean;
+	keepTriggerSymbol: boolean;
 }
 
 export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
@@ -44,6 +45,7 @@ export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
 	invalidCharacterRegexFlags: "i",
 
 	removeAccents: true,
+	keepTriggerSymbol: false,
 };
 
 const arrayMove = <T>(array: T[], fromIndex: number, toIndex: number): void => {
@@ -421,6 +423,19 @@ export class SettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.removeAccents)
 					.onChange((value: boolean) => {
 						this.plugin.settings.removeAccents = value;
+						this.plugin.saveSettings();
+					})
+			);
+		
+		// Retain @ in file name
+		new Setting(this.containerEl)
+			.setName("Retain the trigger symbol for file name")
+			.setDesc("Retain a literal <trigger symbol> at the start of the file names")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.keepTriggerSymbol)
+					.onChange((value: boolean) => {
+						this.plugin.settings.keepTriggerSymbol = value;
 						this.plugin.saveSettings();
 					})
 			);

--- a/src/shared-suggestion/sharedGetSuggestions.ts
+++ b/src/shared-suggestion/sharedGetSuggestions.ts
@@ -91,12 +91,17 @@ export function sharedGetSuggestions(
 					!result.obj?.isCreateNewOption
 			);
 			const separator = settings.addNewNoteDirectory ? "/" : "";
+
+			let filePath = `${settings.addNewNoteDirectory.trim()}${separator}`
+			if (settings.keepTriggerSymbol)
+				filePath += settings.triggerSymbol
+			filePath += `${query.trim()}.md`
 			results.push({
 				obj: {
 					isCreateNewOption: true,
 					query: query,
 					fileName: "Create new note",
-					filePath: `${settings.addNewNoteDirectory.trim()}${separator}${query.trim()}.md`,
+					filePath,
 				},
 			});
 		}

--- a/src/shared-suggestion/sharedSelectSuggestion.ts
+++ b/src/shared-suggestion/sharedSelectSuggestion.ts
@@ -26,16 +26,18 @@ export async function sharedSelectSuggestion(
 			);
 		}
 
+		let filePath: string|null=null;
 		try {
-			linkFile = await app.vault.create(
-				value.obj?.filePath,
-				newNoteContents
-			);
+			if (settings.keepTriggerSymbol)
+				filePath = value.obj?.filePath.replace(/([^/]+)$/, `${settings.triggerSymbol}$1`);
+			else
+				filePath = value.obj?.filePath;
+			linkFile = await app.vault.create(filePath, newNoteContents);
 			// Update the alias to the name for displaying the @ link
 			value.obj.alias = value.obj?.query;
 		} catch (error) {
 			new Notice(
-				`Unable to create new note at path: ${value.obj?.filePath}. Please open an issue on GitHub, https://github.com/Ebonsignori/obsidian-at-symbol-linking/issues`,
+				`Unable to create new note at path: ${filePath}. Please open an issue on GitHub, https://github.com/Ebonsignori/obsidian-at-symbol-linking/issues`,
 				0
 			);
 			throw error;
@@ -48,8 +50,8 @@ export async function sharedSelectSuggestion(
 			value.obj?.filePath
 		) as TFile;
 	}
-	let alias = value.obj?.alias || "";
-	if (settings.includeSymbol) alias = `${settings.triggerSymbol}${alias || value.obj?.fileName}`;
+	let alias = settings.keepTriggerSymbol ? "" : (value.obj?.alias || "");
+	if (settings.includeSymbol && !settings.keepTriggerSymbol) alias = `${settings.triggerSymbol}${alias || value.obj?.fileName}`;
 	let linkText = app.fileManager.generateMarkdownLink(
 		linkFile,
 		currentFile?.path || "",


### PR DESCRIPTION
Adds an option in advanced settings to keep the literal trigger symbol in the resulting file name when you create new notes with the plugin. For example, when enabled in settings, typing `@Foo Bar` and then tabbing will create a file with the literal name `@Foo Bar.md`.

I like all my people notes to start with @ so I can easily identify that the note is a "person" note. I can see other similar use cases where they symbol can somehow specify the "type" of file to the user easily.