### PR TITLE
Add option to include the trigger symbol in link alias but not link text

### DIFF
--- a/src/native-suggestion/suggest-popup.ts
+++ b/src/native-suggestion/suggest-popup.ts
@@ -118,7 +118,7 @@ export default class SuggestionPopup extends EditorSuggest<
 			});
 		}
 
-		// If query has more spaces alloted by the leavePopupOpenForXSpaces setting, close
+		// If query has more spaces allocated by the leavePopupOpenForXSpaces setting, close
 		if (
 			query.split(" ").length - 1 >
 				this.settings.leavePopupOpenForXSpaces ||

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -118,7 +118,7 @@ export class SettingsTab extends PluginSettingTab {
 		);
 
 		new Setting(this.containerEl)
-			.setName(`Include ${this.plugin.settings.triggerSymbol} symbol`)
+			.setName(`Include ${this.plugin.settings.triggerSymbol} symbol in link text`)
 			.setDesc(includeSymbolDesc)
 			.addToggle((toggle) =>
 				toggle
@@ -134,13 +134,13 @@ export class SettingsTab extends PluginSettingTab {
 		// Begin includeSymbolInAlias option: Determine whether to include @ symbol in link alias
 		const includeSymbolInAliasDesc = document.createDocumentFragment();
 		includeSymbolInAliasDesc.append(
-			`Include the ${this.plugin.settings.triggerSymbol} symbol prefixing the final alias text`,
+			`Include the ${this.plugin.settings.triggerSymbol} symbol prefixing the final link alias text`,
 			includeSymbolInAliasDesc.createEl("br"),
 			includeSymbolInAliasDesc.createEl("em", {text: exampleText,})
 		);
 
 		new Setting(this.containerEl)
-			.setName(`Include ${this.plugin.settings.triggerSymbol} in alias`)
+			.setName(`Include ${this.plugin.settings.triggerSymbol} symbol in link alias`)
 			.setDesc(includeSymbolInAliasDesc)
 			.addToggle((toggle) =>
 				toggle

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -11,7 +11,10 @@ import { FileSuggest } from "./file-suggest";
 
 export interface AtSymbolLinkingSettings {
 	triggerSymbol: string;
+
 	includeSymbol: boolean;
+	includeSymbolInAlias: boolean;
+
 	limitLinkDirectories: Array<string>;
 
 	showAddNewNote: boolean;
@@ -30,7 +33,9 @@ export interface AtSymbolLinkingSettings {
 export const DEFAULT_SETTINGS: AtSymbolLinkingSettings = {
 	triggerSymbol: "@",
 	limitLinkDirectories: [],
+
 	includeSymbol: true,
+	includeSymbolInAlias: false,
 
 	showAddNewNote: false,
 	addNewNoteTemplateFile: "",
@@ -93,19 +98,25 @@ export class SettingsTab extends PluginSettingTab {
 				};
 			});
 
+		const exampleText = `E.g. [[${
+			this.plugin.settings.includeSymbol
+				? this.plugin.settings.triggerSymbol
+				: ""
+		}evan|${
+			this.plugin.settings.includeSymbolInAlias
+				? this.plugin.settings.triggerSymbol
+				: ""
+		}evan]]`;
+
 		// Begin includeSymbol option: Determine whether to include @ symbol in link
 		const includeSymbolDesc = document.createDocumentFragment();
+
 		includeSymbolDesc.append(
 			`Include the ${this.plugin.settings.triggerSymbol} symbol prefixing the final link text`,
 			includeSymbolDesc.createEl("br"),
-			includeSymbolDesc.createEl("em", {
-				text: `E.g. [${
-					this.plugin.settings.includeSymbol
-						? this.plugin.settings.triggerSymbol
-						: ""
-				}evan](./evan)`,
-			})
+			includeSymbolDesc.createEl("em", {text: exampleText})
 		);
+
 		new Setting(this.containerEl)
 			.setName(`Include ${this.plugin.settings.triggerSymbol} symbol`)
 			.setDesc(includeSymbolDesc)
@@ -119,6 +130,28 @@ export class SettingsTab extends PluginSettingTab {
 					})
 			);
 		// End includeSymbol option
+
+		// Begin includeSymbolInAlias option: Determine whether to include @ symbol in link alias
+		const includeSymbolInAliasDesc = document.createDocumentFragment();
+		includeSymbolInAliasDesc.append(
+			`Include the ${this.plugin.settings.triggerSymbol} symbol prefixing the final alias text`,
+			includeSymbolInAliasDesc.createEl("br"),
+			includeSymbolInAliasDesc.createEl("em", {text: exampleText,})
+		);
+
+		new Setting(this.containerEl)
+			.setName(`Include ${this.plugin.settings.triggerSymbol} in alias`)
+			.setDesc(includeSymbolInAliasDesc)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.includeSymbolInAlias)
+					.onChange((value: boolean) => {
+						this.plugin.settings.includeSymbolInAlias = value;
+						this.plugin.saveSettings();
+						this.display();
+					})
+			);
+		// End includeSymbolInAlias option
 
 		// Begin limitLinksToFolders option: limit which folders links are sourced from
 		const ruleDesc = document.createDocumentFragment();

--- a/src/shared-suggestion/sharedSelectSuggestion.ts
+++ b/src/shared-suggestion/sharedSelectSuggestion.ts
@@ -10,8 +10,21 @@ export async function sharedSelectSuggestion(
 	value: Fuzzysort.KeysResult<fileOption>
 ): Promise<string> {
 	// When user selects "Create new note" option, create the note to link to
-	let linkFile;
+	let linkFile: TFile | undefined;
 	if (value?.obj?.isCreateNewOption) {
+		if (settings.includeSymbol) {
+			const filePath = value.obj.filePath;
+			let filePathParts = filePath.split("/");
+	
+			let fileName = filePathParts[filePathParts.length - 1];
+			fileName = settings.triggerSymbol + fileName;
+	
+			filePathParts = filePathParts.slice(0, filePathParts.length - 1);
+			filePathParts.push(fileName);
+	
+			value.obj.filePath = filePathParts.join("/");
+			console.log("Final file path:", value.obj.filePath);
+		}
 		let newNoteContents = "";
 		if (settings.addNewNoteTemplateFile) {
 			const fileTemplate = app.vault.getAbstractFileByPath(
@@ -49,7 +62,13 @@ export async function sharedSelectSuggestion(
 		) as TFile;
 	}
 	let alias = value.obj?.alias || "";
-	if (settings.includeSymbol) alias = `${settings.triggerSymbol}${alias || value.obj?.fileName}`;
+	if (settings.includeSymbolInAlias) {
+		alias = `${settings.triggerSymbol}${alias || value.obj.fileName}`;
+	} else {
+		alias = `${
+			alias || value.obj.fileName.replace(settings.triggerSymbol, "")
+		}`;
+	}
 	let linkText = app.fileManager.generateMarkdownLink(
 		linkFile,
 		currentFile?.path || "",

--- a/src/utils/suggest.ts
+++ b/src/utils/suggest.ts
@@ -205,5 +205,5 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 }
 
 export const wrapAround = (value: number, size: number): number => {
-	return ((value % size) + size) % size;
+	return value % size;
 };


### PR DESCRIPTION
This pull request allows users to more thoroughly configure how they want links to work in this plugin.

Currently, there is an option to include/not include the `triggerSymbol` string at the start of the names of newly created files, however you can't independently configure whether the `triggerSymbol` should also appear in the link alias or not.

Example:
*User uses this plugin to create new file `@Person`*
The resulting link will be either `[[@Person]]` or `[[Person]]`.

This pull request adds two other possibilities:
- `[[@Person|Person]]`
- `[[Person|@Person]]`

Here `@` is used as the `triggerSymbol`.

For example, If you don't want your files to start with the `triggerSymbol`, but want to include it in your notes, you would use `[[Person|@Person]]`.